### PR TITLE
fix(fetch): using &str instead String

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -68,19 +68,14 @@ pub fn fetch_bytes(path: &str) -> Result<Vec<u8>> {
   }
 }
 
-pub async fn download_to_file(url: String, file: PathBuf) -> Result<()> {
-  let data: Vec<u8> = fetch::fetch_bytes(&url)?;
+pub async fn download_to_file(url: &str, file: &PathBuf) -> Result<()> {
+  let data: Vec<u8> = fetch::fetch_bytes(url)?;
   std::fs::write(file, &data)?;
   Ok(())
 }
 
 pub async fn batch_download_to_file(items: Vec<(String, PathBuf)>) -> Result<()> {
-  let result = futures::future::join_all(
-    items
-      .iter()
-      .map(|item| download_to_file(item.0.clone(), item.1.clone())),
-  )
-  .await;
+  let result = futures::future::join_all(items.iter().map(|(url, file)| download_to_file(url, file))).await;
   for item in result {
     item?;
   }


### PR DESCRIPTION
Now you don't need to use the clone method.